### PR TITLE
fix: expose ckb-indexer outside of Docker container on 8116 port

### DIFF
--- a/godwoken_entrypoint.sh
+++ b/godwoken_entrypoint.sh
@@ -28,7 +28,7 @@ cd ${PROJECT_DIR}/godwoken
 
 # first, start ckb-indexer 
 # todo: should remove to another service. but the port mapping some how not working.
-RUST_LOG=error ckb-indexer -s ${PROJECT_DIR}/indexer-data/ckb-indexer-data -c ${CKB_RPC} > ${PROJECT_DIR}/indexer-data/indexer-log & 
+RUST_LOG=error ckb-indexer -s ${PROJECT_DIR}/indexer-data/ckb-indexer-data -c ${CKB_RPC} -l 0.0.0.0:8116 > ${PROJECT_DIR}/indexer-data/indexer-log & 
  
 # detect which mode to start godwoken
 if test -f "$GODWOKEN_CONFIG_TOML_FILE"; then


### PR DESCRIPTION
It used to default to 127.0.0.1:8116 in ckb-indexer therefore it wasn't accessible outside of the Docker container. Changing 127.0.0.1 to 0.0.0.0 host does the job.

The hostname is verified in JSON RPC HTTP crate in Rust in ckb-indexer.