### PR TITLE
enable CKB RPC ws_listen_address in ckb.toml

### DIFF
--- a/ckb-data/ckb.toml
+++ b/ckb-data/ckb.toml
@@ -81,7 +81,7 @@ modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment
 
 # By default RPC only binds to HTTP service, you can bind it to TCP and WebSocket.
 # tcp_listen_address = "127.0.0.1:18114"
-# ws_listen_address = "127.0.0.1:28114"
+ws_listen_address = "0.0.0.0:28114"
 reject_ill_transactions = true
 
 # By default deprecated rpc methods are disabled.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,9 +23,10 @@ services:
       context: layer1
       args: 
         DOCKER_PREBUILD_IMAGE: "${DOCKER_PREBUILD_IMAGE_NAME}:${DOCKER_PREBUILD_IMAGE_TAG}"
-    ports: 
+    ports:
+    - 28114:28114 # rpc.ws_listen_address
     - 8114:8114
-    - 8115:8115 # 8115 is not using for now, but we may need it when extend kicker in the future
+    - 8115:8115   # 8115 is not using for now, but we may need it when extend kicker in the future
     volumes:
     - ../ckb-data/:/ckb-data
     environment:


### PR DESCRIPTION
Subscriptions require a full duplex connection. CKB offers such connections in the form of TCP (enable with rpc.tcp_listen_address configuration option) and WebSockets (enable with rpc.ws_listen_address).