### PR TITLE
docs: rename capsule to ckb-capsule

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ if you are using custom-mode:
 - [docker-compose](https://docs.docker.com/compose/)
 - [moleculec](https://github.com/nervosnetwork/molecule) 0.7.2 (cargo install moleculec)
 - nodejs 14 && yarn ([how to install](https://yarnpkg.com/lang/en/docs/install/))
-- [capsule](https://github.com/nervosnetwork/capsule) v0.7.0 (cargo install capsule)
+- [capsule](https://github.com/nervosnetwork/capsule) v0.7.0 (cargo install ckb-capsule)
 
 ## How Kicker Works
 


### PR DESCRIPTION
The module has been renamed from capsule to ckb-capsule on cargo.