### PR TITLE
feat: support deposit/get-balance instructions

### DIFF
--- a/.github/workflows/hardhat-simple-project.yml
+++ b/.github/workflows/hardhat-simple-project.yml
@@ -23,7 +23,7 @@ jobs:
       - run: ./kicker -- top
       - run: ./kicker -- exec -i ckb ls -l
       - run: ./kicker -- help
-      - run: ./kicker deposit config/private_key 1000
+      - run: ./kicker deposit 0xCD1d13450cFA630728D0390C99957C6948BF7d19 1000
 
       - run: echo "Part 2. Deploy A Simple Contract Using Hardhat"
       - run: git clone --depth=1 https://github.com/NomicFoundation/hardhat
@@ -31,7 +31,7 @@ jobs:
         working-directory: hardhat/packages/hardhat-core/sample-projects/basic/
       - name: Adapt hardhat.config.js to our local network of Godwoken
         run: |
-          sed -i 's#solidity:#    networks: { gw_devnet_v1: { url: `http://localhost:8024`, accounts: [`0x6cd5e7be2f6504aa5ae7c0c04178d8f47b7cfc63b71d95d9e6282f5b090431bf`, `0xdd50cac37ec6dd12539a968c1a2cbedda75bd8724f7bcad486548eaabb87fc8b`], } }, solidity:#g' hardhat.config.js
+          sed -i 's#solidity:#    networks: { gw_devnet_v1: { url: `http://127.0.0.1:8024`, accounts: [`0x9d5bc55413c14cf4ce360a6051eacdc0e580100a0d3f7f2f48f63623f6b05361`], } }, solidity:#g' hardhat.config.js
           cat hardhat.config.js
         working-directory: hardhat/packages/hardhat-core/sample-projects/basic/
       - run: npx hardhat accounts --network gw_devnet_v1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ One line command to start a local network of [Godwoken](https://github.com/nervo
 
 ## Getting Started
 
-1. [Deploy local network of Godwoken using Godwoken-Kicker](./docs/kicker-start.md)
+1. [Deploy local network of Godwoken](./docs/kicker-start.md)
 
 2. [Deploy a simple contract using Hardhat](./docs/hardhat-simple-project.md)
 

--- a/docker/layer2/setup-godwoken.sh
+++ b/docker/layer2/setup-godwoken.sh
@@ -211,6 +211,9 @@ function deposit-and-create-polyjuice-creator-account() {
     > /var/tmp/gw-tools.log 2>&1
     stop-godwoken
 
+    # update block_producer.account_id
+    sed -i 's#^account_id = .*$#account_id = 2#' $CONFIG_DIR/godwoken-config.toml
+
     cat /var/tmp/gw-tools.log
     tail -n 1 /var/tmp/gw-tools.log | grep -oE '[0-9]+$' > $CONFIG_DIR/polyjuice-creator-account-id
 

--- a/docs/hardhat-simple-project.md
+++ b/docs/hardhat-simple-project.md
@@ -30,14 +30,17 @@ module.exports = {
 
   networks: {
     gw_devnet_v1: {
-      url: `http://localhost:8024`,
-      accounts: [`0x6cd5e7be2f6504aa5ae7c0c04178d8f47b7cfc63b71d95d9e6282f5b090431bf`, `0xdd50cac37ec6dd12539a968c1a2cbedda75bd8724f7bcad486548eaabb87fc8b`],
+      url: `http://127.0.0.1:8024`,
+      accounts: [`0x9d5bc55413c14cf4ce360a6051eacdc0e580100a0d3f7f2f48f63623f6b05361`],
     }
   },
 
   ...
 }
 ```
+
+* `http://127.0.0.1:8024` is the Godwoken Web3 URL, which should be deployed at [deploy-a-local-network-of-godwoken-using-godwoken-kicker](./kicker-start.md#deploy-a-local-network-of-godwoken-using-godwoken-kicker)
+* `0x9d5bc55413c14cf4ce360a6051eacdc0e580100a0d3f7f2f48f63623f6b05361` is the private key of account we used at [deposit-some-ckb-to-layer2-account](./kicker-start.md#deposit-some-ckb-to-layer2-account). You can replace it with your testing keys.
 
 ### Run hardhat on our local network of Godwoken by `--network gw_devnet_v1`
 

--- a/docs/kicker-start.md
+++ b/docs/kicker-start.md
@@ -15,7 +15,7 @@ cd godwoken-kicker
 ./kicker start
 ```
 
-This command deploys a local network of godwoken. Upon completion, the following docker containers should be running(see more [`docker-compose.yml`](./docker/docker-compose.yml)):
+This command deploys a local network of godwoken. Upon completion, the following docker containers should be running(see more [`docker-compose.yml`](../docker/docker-compose.yml)):
   - `docker_ckb_1`
   - `docker_ckb-miner_1`
   - `docker_ckb-indexer_1`
@@ -30,11 +30,28 @@ Note that it might take several minutes on the first run. You can use `./kicker 
 ```shell
 $ ./kicker info
 Web3 RPC URL: http://127.0.0.1:8024
-Accounts:
-  - Private Key: 0xdd50cac37ec6dd12539a968c1a2cbedda75bd8724f7bcad486548eaabb87fc8b
-    ETH Address: 0x0C1EfCCa2Bcb65A532274f3eF24c044EF4ab6D73
-  - Private Key: 0x6cd5e7be2f6504aa5ae7c0c04178d8f47b7cfc63b71d95d9e6282f5b090431bf
-    ETH Address: 0x6DaF63D8411D6E23552658E3cFb48416A6A2CA78
+```
+
+## Deposit some CKB to layer2 account
+
+In this example, we use the private key *0x9d5bc55413c14cf4ce360a6051eacdc0e580100a0d3f7f2f48f63623f6b05361* and the ETH address is `0xCD1d13450cFA630728D0390C99957C6948BF7d19`.
+
+```shell
+$ ./kicker get-balance 0xCD1d13450cFA630728D0390C99957C6948BF7d19
+Balance: 0
+
+$ ./kicker deposit 0xCD1d13450cFA630728D0390C99957C6948BF7d19 999
+eth address: 0xcd1d13450cfa630728d0390c99957c6948bf7d19
+layer2 script hash: 0x75e830169e5a0ce461b05e7db195a7cec8b21a2783620d735a1e77c7937686b0
+short script hash: 0x75e830169e5a0ce461b05e7db195a7cec8b21a27
+tx_hash: 0x115b11dbeee6ccf1c0879ea7e5b554d1664ec0114be963dad0f4f2ed5d32bc42
+...
+current balance: 99900000000, waiting for 8 secs.
+deposit success!
+Your account id: 53
+
+$ ./kicker get-balance 0xCD1d13450cFA630728D0390C99957C6948BF7d19
+Balance: 99900000000
 ```
 
 ## What next

--- a/kicker
+++ b/kicker
@@ -28,7 +28,8 @@ function usage() {
     echo "  logs [service]          Tail target service's logs"
     echo "  enter <service>         Enter target service's container"
     echo "  manual-build            Manually build services artifacts"
-    echo "  deposit <privkey-path> <capacity>   Deposit from layer1(CKB network) to layer2 Godwoken network"
+    echo "  deposit <eth-address> <amount>  Deposit CKB to layer2"
+    echo "  get-balance <eth-address>       Get layer2 balance"
     echo
     echo "EXAMPLES:"
     echo "  * Deploy the local network and print service info"
@@ -38,7 +39,8 @@ function usage() {
     echo
     echo "  * Deposit 1000CKB from layer1 to layer2"
     echo
-    echo "    $ $EXECUTABLE deposit config/private_key 1000"
+    echo "    $ $EXECUTABLE deposit 0x618cc3C660cEBFDbA8570CA739b1744AE3E2553a 1000"
+    echo "    $ $EXECUTABLE get-balance 0x618cc3C660cEBFDbA8570CA739b1744AE3E2553a"
     echo
     echo "  * Redeploy the local network"
     echo
@@ -111,17 +113,7 @@ function stop() {
 }
 
 function info_() {
-    if [ "$(cat $WORKSPACE/config/private_key)" != "0xdd50cac37ec6dd12539a968c1a2cbedda75bd8724f7bcad486548eaabb87fc8b" ]; then
-        error "\"$EXECUTABLE info\" cannot work now"
-        exit 1
-    fi
-    
     echo "Web3 RPC URL: http://127.0.0.1:8024"
-    echo "Accounts:"
-    echo "  - Private Key: 0xdd50cac37ec6dd12539a968c1a2cbedda75bd8724f7bcad486548eaabb87fc8b"
-    echo "    ETH Address: 0x0C1EfCCa2Bcb65A532274f3eF24c044EF4ab6D73"
-    echo "  - Private Key: 0x6cd5e7be2f6504aa5ae7c0c04178d8f47b7cfc63b71d95d9e6282f5b090431bf"
-    echo "    ETH Address: 0x6DaF63D8411D6E23552658E3cFb48416A6A2CA78"
 }
 
 function clean() {
@@ -175,28 +167,70 @@ function enter() {
     compose exec "$service" /bin/bash
 }
 
+# @example deposit "0x0C1EfCCa2Bcb65A532274f3eF24c044EF4ab6D73" 1000
 function deposit() {
-    pkpath=${1:?"\"$EXECUTABLE deposit\" requires privkey path as 1st argument"}
-    capacity=${2:?"\"$EXECUTABLE deposit\" requires capacity as 2nd argument"}
+    ethaddr=${1:?"\"$EXECUTABLE deposit\" requires eth address as 1st argument"}
+    amount=${2:?"\"$EXECUTABLE deposit\" requires amount as 2nd argument"}
 
+    pkpath=${PRIVATE_KEY_PATH:-"$WORKSPACE/config/private_key"}
     if [ ! -f $pkpath ]; then
         error "$pkpath: No such file or directory"
         exit 1
     fi
 
     abspkpath="$( cd -- "$(dirname "$pkpath")" >/dev/null 2>&1 ; pwd -P )/$(basename $pkpath)"
-    compose run --no-deps \
+    docker-compose -f docker/docker-compose.yml run \
+        --no-deps \
         --use-aliases \
         --volume=$WORKSPACE/docker/layer2/config:/config \
         --volume=$abspkpath:/privkey-path \
-        --entrypoint "\"gw-tools deposit-ckb \
+        --entrypoint "gw-tools deposit-ckb \
                 --godwoken-rpc-url http://godwoken:8119 \
                 --ckb-rpc http://ckb:8114 \
                 --scripts-deployment-path /config/scripts-deployment.json \
                 --config-path /config/godwoken-config.toml \
                 --privkey-path /privkey-path \
-                --capacity $capacity\"" \
+                --eth-address $ethaddr \
+                --capacity $amount" \
         godwoken
+}
+
+# Note that this function MUST be in tty mode.
+# @example get-balance "0x0C1EfCCa2Bcb65A532274f3eF24c044EF4ab6D73"
+function get-balance() {
+    ethaddr=${1:?"\"$EXECUTABLE deposit\" requires eth address as 1st argument"}
+    pkpath=$WORKSPACE/config/private_key
+    if [ ! -f $pkpath ]; then
+        error "$pkpath: No such file or directory"
+        exit 1
+    fi
+
+    abspkpath="$( cd -- "$(dirname "$pkpath")" >/dev/null 2>&1 ; pwd -P )/$(basename $pkpath)"
+    short_script_hash=$(to-short-script-hash "$ethaddr")
+    docker-compose -f docker/docker-compose.yml run \
+        --no-deps \
+        --use-aliases \
+        --volume=$WORKSPACE/docker/layer2/config:/config \
+        --volume=$abspkpath:/privkey-path \
+        --entrypoint "gw-tools get-balance \
+            --godwoken-rpc-url http://godwoken:8119 \
+            --account $short_script_hash" \
+        godwoken
+}
+
+# @to-short-script-hash "0x0C1EfCCa2Bcb65A532274f3eF24c044EF4ab6D73"
+function to-short-script-hash() {
+    ethaddr=${1:?"\"$EXECUTABLE deposit\" requires eth address as 1st argument"}
+    output=$(docker-compose -f docker/docker-compose.yml run \
+        --no-deps \
+        --use-aliases \
+        --volume=$WORKSPACE/docker/layer2/config:/config \
+        --entrypoint "gw-tools to-short-script-hash \
+            --config-path /config/godwoken-config.toml \
+            --scripts-deployment-path /config/scripts-deployment.json \
+            --eth-address $ethaddr" \
+            godwoken)
+    echo "$output" | grep -oE '0x.*'
 }
 
 # @example MANUAL_BUILD_WEB3=true \
@@ -363,6 +397,9 @@ function main() {
             ;;
         "deposit")
             deposit "$@"
+            ;;
+        "get-balance")
+            get-balance "$@"
             ;;
         "manual-build")
             manual-build


### PR DESCRIPTION
Usage:

```
    $ ./kicker deposit 0x618cc3C660cEBFDbA8570CA739b1744AE3E2553a 1000
    $ ./kicker get-balance 0x618cc3C660cEBFDbA8570CA739b1744AE3E2553a
```

`kicker deposit` deposits capacity from account `config/private_key` to the given eth-address.