### PR TITLE
Update block_producer.account_id

### DIFF
--- a/docker/layer2/setup-godwoken.sh
+++ b/docker/layer2/setup-godwoken.sh
@@ -211,6 +211,9 @@ function deposit-and-create-polyjuice-creator-account() {
     > /var/tmp/gw-tools.log 2>&1
     stop-godwoken
 
+    # update block_producer.account_id
+    sed -i 's#^account_id = .*$#account_id = 2#' $CONFIG_DIR/godwoken-config.toml
+
     cat /var/tmp/gw-tools.log
     tail -n 1 /var/tmp/gw-tools.log | grep -oE '[0-9]+$' > $CONFIG_DIR/polyjuice-creator-account-id
 


### PR DESCRIPTION
## Setup block_producer.account_id
account_id 2 is related to $PRIVATE_KEY_PATH, which is the first EOA account of kicker devnet_v1.

Note: 
0 and 1 are reserved by Godwoken. 
see: 
https://github.com/nervosnetwork/godwoken/blob/168666c/crates/common/src/builtins.rs#L4

## Related PR
- https://github.com/nervosnetwork/godwoken-polyjuice/pull/130