### PR TITLE
fix clean cmd failed in mac(m1)

### DIFF
--- a/kicker
+++ b/kicker
@@ -117,8 +117,8 @@ function info_() {
 }
 
 function clean() {
-    n_alive=$(compose ps --quiet | grep -oE '[0-9a-z]{64}' | wc -l)
-    if [ "$n_alive" != "0" ]; then
+    n_alive=$(compose ps --quiet | grep -oE '[0-9a-z]{64}' | wc -l | tr -d " ")
+    if [ $n_alive != 0 ]; then
         error "Ensure container services are down"
         compose ps
         exit 1


### PR DESCRIPTION
The result of `wc -l` command execution has spaces and "0" are not equal
<img width="478" alt="image" src="https://user-images.githubusercontent.com/32102187/158949932-353ae18c-2e5c-4950-95b7-2238dd3f4e7b.png">
