### PR TITLE
fix: incorrectly use bit shift priority

### DIFF
--- a/docker/layer2/entrypoint.sh
+++ b/docker/layer2/entrypoint.sh
@@ -234,7 +234,7 @@ PORT=8024
 # * https://eips.ethereum.org/EIPS/eip-1344#specification
 CREATOR_ACCOUNT_ID=$creator_account_id
 COMPATIBLE_CHAIN_ID=$COMPATIBLE_CHAIN_ID
-CHAIN_ID=$(($COMPATIBLE_CHAIN_ID << 32 + $creator_account_id))
+CHAIN_ID=$((($COMPATIBLE_CHAIN_ID << 32) + $creator_account_id))
 
 # When requests "executeTransaction" RPC interface, the RawL2Transaction's
 # signature can be omit. Therefore we fill the RawL2Transaction.from_id


### PR DESCRIPTION
```
$ bash -c 'echo $((1984 << 32 + 4))'
136339441844224

$ zsh -c 'echo $((1984 << 32 + 4))'
8521215115268
```

```
$bash -c 'echo $(((1984 << 32 ) + 4))'
8521215115268

$ zsh -c 'echo $(((1984 << 32 ) + 4))'
8521215115268
```