### PR TITLE
fix: remove `--no-deps` from docker-compose commands

### DIFF
--- a/.github/workflows/hardhat-simple-project.yml
+++ b/.github/workflows/hardhat-simple-project.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Godwoken-Kicker
         uses: actions/checkout@v2
       - run: git rev-parse HEAD
-      - run: ./kicker init
+      - run: MANUAL_BUILD_GODWOKEN=true GODWOKEN_GIT_URL=https://github.com/nervosnetwork/godwoken GODWOKEN_GIT_CHECKOUT=527025a5163d035aaf63a54b22d2a67286f13704 ./kicker init
       - run: ./kicker start
       - run: ./kicker info
       - run: ./kicker ps

--- a/docker/layer1/ckb/ckb.toml
+++ b/docker/layer1/ckb/ckb.toml
@@ -10,7 +10,7 @@ data_dir = "data"
 spec = { file = "specs/dev.toml" }
 
 [logger]
-filter = "info"
+filter = "info,ckb=debug"
 color = true
 log_to_file = true
 log_to_stdout = true

--- a/kicker
+++ b/kicker
@@ -210,25 +210,20 @@ function deposit() {
     fi
 
     abspkpath="$( cd -- "$(dirname "$pkpath")" >/dev/null 2>&1 ; pwd -P )/$(basename $pkpath)"
-    # FIXME: Deposit CKB error: invalid type: null, expected struct TransactionView
-    # => fix wait_for_tx function in gw-tools
-    while true; do
-        docker-compose -f docker/docker-compose.yml run \
-            --no-deps \
-            --use-aliases \
-            --volume=$WORKSPACE/docker/layer2/config:/config \
-            --volume=$abspkpath:/privkey-path \
-            --entrypoint "gw-tools deposit-ckb \
-                    --godwoken-rpc-url http://godwoken:8119 \
-                    --ckb-rpc http://ckb:8114 \
-                    --scripts-deployment-path /config/scripts-deployment.json \
-                    --config-path /config/godwoken-config.toml \
-                    --privkey-path /privkey-path \
-                    --eth-address $ethaddr \
-                    --capacity $amount" \
-            godwoken && echo "Deposit finished" && break
-        sleep 6 && echo "Retry"
-    done
+    docker-compose -f docker/docker-compose.yml run \
+        --no-deps \
+        --use-aliases \
+        --volume=$WORKSPACE/docker/layer2/config:/config \
+        --volume=$abspkpath:/privkey-path \
+        --entrypoint "gw-tools deposit-ckb \
+                --godwoken-rpc-url http://godwoken:8119 \
+                --ckb-rpc http://ckb:8114 \
+                --scripts-deployment-path /config/scripts-deployment.json \
+                --config-path /config/godwoken-config.toml \
+                --privkey-path /privkey-path \
+                --eth-address $ethaddr \
+                --capacity $amount" \
+        godwoken && echo "Deposit finished"
 }
 
 # Note that this function MUST be in tty mode.

--- a/kicker
+++ b/kicker
@@ -211,7 +211,6 @@ function deposit() {
 
     abspkpath="$( cd -- "$(dirname "$pkpath")" >/dev/null 2>&1 ; pwd -P )/$(basename $pkpath)"
     docker-compose -f docker/docker-compose.yml run \
-        --no-deps \
         --use-aliases \
         --volume=$WORKSPACE/docker/layer2/config:/config \
         --volume=$abspkpath:/privkey-path \
@@ -232,7 +231,6 @@ function get-balance() {
     ethaddr=${1:?"\"$EXECUTABLE get-balance\" requires eth address as 1st argument"}
     short_script_hash=$(to-short-script-hash "$ethaddr")
     docker-compose -f docker/docker-compose.yml run \
-        --no-deps \
         --use-aliases \
         --entrypoint "gw-tools get-balance \
             --godwoken-rpc-url http://godwoken:8119 \
@@ -244,7 +242,6 @@ function get-balance() {
 function to-short-script-hash() {
     ethaddr=${1:?"\"$EXECUTABLE to-short-script-hash\" requires eth address as 1st argument"}
     output=$(docker-compose -f docker/docker-compose.yml run \
-        --no-deps \
         --use-aliases \
         --volume=$WORKSPACE/docker/layer2/config:/config \
         --entrypoint "gw-tools to-short-script-hash \
@@ -298,7 +295,6 @@ function manual-build() {
         # the `docker/manual-artifacts` directory, it is not what we expect.
         erun docker-compose -f docker/docker-compose.yml run \
             --rm \
-            --no-deps \
             --volume=$WORKSPACE/packages/godwoken-web3:/app \
             --workdir=/app \
             --entrypoint "\"yarn install\"" \


### PR DESCRIPTION
Fix https://github.com/RetricSu/godwoken-kicker/issues/228

This PR does two things:

* Remove retries of `kicker deposit`
* Remove `--no-deps` from docker-compose commands