### PR TITLE
chore: enable ckb debug logs

### DIFF
--- a/docker/layer1/ckb/ckb.toml
+++ b/docker/layer1/ckb/ckb.toml
@@ -10,7 +10,7 @@ data_dir = "data"
 spec = { file = "specs/dev.toml" }
 
 [logger]
-filter = "info"
+filter = "info,ckb=debug"
 color = true
 log_to_file = true
 log_to_stdout = true


### PR DESCRIPTION
CKB seems unstable: https://github.com/RetricSu/godwoken-kicker/runs/6071639933?check_suite_focus=true

I would like to enable CKB's debug logs to find out why.