### PR TITLE
fix: web3-indexer depends_on web3 healthy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -159,7 +159,7 @@ services:
         max_attempts: 10
     depends_on: 
       web3:
-        condition: service_started
+        condition: service_healthy
       godwoken:
         condition: service_healthy
       postgres:


### PR DESCRIPTION
Why: Web3-indexer will request web3 service throught HTTP interfaces. So
it has to wait until web3 service started and become healthy.

How: web3-indexer::depends_on::condition::web3::service_healthy