### PR TITLE
refactor: Simplify Web3 configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ plugins/gw-schema/tmp
 /docker/layer2/config/rollup-genesis-deployment.json
 /docker/layer2/config/godwoken-config.toml
 /docker/layer2/config/polyjuice-root-account-id
-/docker/layer2/config/web3-config.env
 /docker/layer2/config/web3-indexer-config.toml
 /docker/manual-artifacts/
 /docker/layer2-v0/data/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -118,10 +118,8 @@ services:
       interval: 10s
       retries: 30
     volumes: 
-      - ./layer2/config:/var/lib/layer2/config
+      - ./layer2/config/web3-config.env:/godwoken-web3/packages/api-server/.env
       - ./web3/entrypoint.sh:/var/lib/web3/entrypoint.sh
-    environment: 
-      CONFIG_DIR: /var/lib/layer2/config
     entrypoint: /var/lib/web3/entrypoint.sh
     ports:
       - 8024:8024

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,9 +83,6 @@ services:
       RUST_BACKTRACE: full
       STORE_PATH: /var/lib/layer2/data
       ACCOUNTS_DIR: /accounts
-      POSTGRES_USER: user
-      POSTGRES_DB: lumos
-      POSTGRES_PASSWORD: password
       GITHUB_RUN_ID: ${GITHUB_RUN_ID:-""}
     volumes:
       - ./layer2:/var/lib/layer2
@@ -111,7 +108,7 @@ services:
         condition: service_completed_successfully
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.1.0-beta
+    image: ghcr.io/nervosnetwork/godwoken-web3-prebuilds:compatibility-breaking-changes-871b301
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
       start_period: 10s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
         condition: service_completed_successfully
 
   godwoken:
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:v1.1.0-beta.1
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:v1.1
     healthcheck:
       test: /var/lib/layer2/healthcheck.sh
       start_period: 10s

--- a/docker/layer2/config/web3-config.env
+++ b/docker/layer2/config/web3-config.env
@@ -1,0 +1,8 @@
+# see: https://github.com/nervosnetwork/godwoken-web3/tree/compatibility-breaking-changes#config-database
+
+DATABASE_URL=postgres://user:password@postgres:5432/lumos
+REDIS_URL=redis://redis:6379
+
+GODWOKEN_JSON_RPC=http://godwoken:8119
+# TODO: add Godwoken readonly node
+# GODWOKEN_READONLY_JSON_RPC=<optional, default equals to GODWOKEN_JSON_RPC>

--- a/docker/web3/entrypoint.sh
+++ b/docker/web3/entrypoint.sh
@@ -3,13 +3,9 @@
 set -o errexit
 #set -o xtrace
 
-WORKSPACE=/godwoken-web3
-
-CONFIG_DIR=$CONFIG_DIR
-cp $CONFIG_DIR/web3-config.env $WORKSPACE/packages/api-server/.env
-
 # create folder for address mapping store
 mkdir -p /usr/local/godwoken-web3/address-mapping
 
-cd $WORKSPACE
+# WORKSPACE=/godwoken-web3
+cd /godwoken-web3
 yarn run start

--- a/kicker
+++ b/kicker
@@ -168,7 +168,6 @@ function clean() {
     echo "rm -f  docker/layer2/config/rollup-genesis-deployment.json"
     echo "rm -f  docker/layer2/config/godwoken-config.toml"
     echo "rm -f  docker/layer2/config/polyjuice-root-account-id"
-    echo "rm -f  docker/layer2/config/web3-config.env"
     echo "rm -f  docker/layer2/config/web3-indexer-config.toml"
     echo "rm -rf docker/ckb-indexer/"
     echo "rm -rf docker/layer1/ckb/data/"
@@ -186,7 +185,6 @@ function clean() {
     rm -f  docker/layer2/config/rollup-genesis-deployment.json
     rm -f  docker/layer2/config/godwoken-config.toml
     rm -f  docker/layer2/config/polyjuice-root-account-id
-    rm -f  docker/layer2/config/web3-config.env
     rm -f  docker/layer2/config/web3-indexer-config.toml
     rm -rf docker/ckb-indexer/
     rm -rf docker/layer1/ckb/data/


### PR DESCRIPTION
- Bump godwoken-prebuilds to v1.1
   https://github.com/nervosnetwork/godwoken-docker-prebuilds/pkgs/container/godwoken-prebuilds/22301245?tag=v1.1
  
      "labels": {
          "ref.component.godwoken-polyjuice": "v1.1.5-beta  2607851",
          "ref.component.godwoken": "v1.1-rc  940dfdec",
          "ref.component.ckb-production-scripts": "rc_lock 47358ce",
          "ref.component.godwoken-scripts": "v1.1.0-beta  03011e0",
      }

- avoid restarting web3 service
   NOTE: In web3 workspace, file changes lead restarting Web3 service 

- refactor: Simplify Web3 configuration 