### PR TITLE
chore: update godwoken image v1-godwoken-f86d655

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,7 +70,7 @@ services:
         condition: service_completed_successfully
 
   godwoken:
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:main-202205170929
+    image: ghcr.io/keroro520/godwoken-prebuilds:v1-godwoken-f86d655
     healthcheck:
       test: /var/lib/layer2/healthcheck.sh
       start_period: 10s


### PR DESCRIPTION
Why: This new image contains several godwoken's bugfixes/enhancements related to kicker:

- https://github.com/nervosnetwork/godwoken/pull/705
- https://github.com/nervosnetwork/godwoken/pull/704
- https://github.com/nervosnetwork/godwoken/pull/702

"ref.component.godwoken": [f86d655](https://github.com/nervosnetwork/godwoken/commit/f86d6559951cef1be6cd64cf8091d9820f3e110f)