### PR TITLE
chore: bump web3/indexer v1.1.2-rc1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -107,7 +107,7 @@ services:
         condition: service_completed_successfully
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.1.1-rc1
+    image: nervos/godwoken-web3-prebuilds:v1.1.2-rc1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
       start_period: 10s
@@ -138,7 +138,7 @@ services:
         condition: service_started
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.1.1-rc1
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.1.2-rc1
     volumes:
       - ./layer2/config:/var/lib/layer2/config
       - ./web3/indexer_entrypoint.sh:/var/lib/web3-indexer/entrypoint.sh


### PR DESCRIPTION
# Web3 release note

## Fixed

* fix(1.1): topic param can be null by @RetricSu in https://github.com/nervosnetwork/godwoken-web3/pull/375

## Others

* chore(deps): bump protobufjs from 6.11.2 to 6.11.3 by @RetricSu in https://github.com/nervosnetwork/godwoken-web3/pull/383
* chore: bump v1.1.2-rc1 by @RetricSu in https://github.com/nervosnetwork/godwoken-web3/pull/384


**Full Changelog**: https://github.com/nervosnetwork/godwoken-web3/compare/v1.1.1-rc1...v1.1.2-rc1