### PR TITLE
Make docker ps more accurate and start/stop faster

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -73,9 +73,9 @@ services:
     image: ghcr.io/flouse/godwoken-prebuilds:1.2-gw-pull-721-merge-202206140118
     healthcheck:
       test: /var/lib/layer2/healthcheck.sh
-      start_period: 10s
-      interval: 30s
-      retries: 600
+      start_period: 600s
+      interval: 10s
+      retries: 3
     environment:
       RUST_LOG: info,gw_generator=debug
       GODWOKEN_MODE: fullnode
@@ -93,7 +93,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-        max_attempts: 1
+        max_attempts: 10
     depends_on:
       postgres:
         condition: service_started
@@ -141,7 +141,7 @@ services:
       test: curl http://127.0.0.1:8024 || exit 1
       start_period: 10s
       interval: 10s
-      retries: 30
+      retries: 3
     volumes:
       - ./layer2/config/web3-config.env:/godwoken-web3/packages/api-server/.env
       - ./web3/entrypoint.sh:/var/lib/web3/entrypoint.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     command: [ "run", "-C", "/var/lib/ckb" ]
 
   ckb-miner:
+    init: true
     image: nervos/ckb:v0.103.0
     user: root
     volumes:
@@ -54,6 +55,7 @@ services:
 
   ckb-indexer:
     image: nervos/ckb-indexer:0.3.2
+    init: true
     environment:
       CKB_RPC: http://ckb:8114
     ports:
@@ -71,6 +73,7 @@ services:
 
   godwoken:
     image: ghcr.io/flouse/godwoken-prebuilds:1.2-gw-pull-721-merge-202206140118
+    init: true
     healthcheck:
       test: /var/lib/layer2/healthcheck.sh
       start_period: 600s
@@ -137,6 +140,7 @@ services:
 
   web3:
     image: nervos/godwoken-web3-prebuilds:v1.1.2-rc1
+    init: true
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
       start_period: 10s
@@ -170,6 +174,7 @@ services:
 
   web3-indexer:
     image: nervos/godwoken-web3-indexer-prebuilds:v1.1.2-rc1
+    init: true
     volumes:
       - ./layer2/config:/var/lib/layer2/config
       - ./web3/indexer_entrypoint.sh:/var/lib/web3-indexer/entrypoint.sh

--- a/docker/web3/entrypoint.sh
+++ b/docker/web3/entrypoint.sh
@@ -10,4 +10,4 @@ mkdir -p /usr/local/godwoken-web3/address-mapping
 cd /godwoken-web3
 
 yarn knex migrate:latest
-yarn run start
+yarn run start:prod


### PR DESCRIPTION
Healthcheck params: a smaller `retries` makes `docker ps` `healthy` information more accurate, while a smaller `interval` makes `kicker start` faster.

Not restarting godwoken in `entrypoint.sh` also makes `docker ps` `healthy` information more accurate.

Using `init: true` makes `kicker stop` much faster and handles reaped processes.