### PR TITLE
Update godwoken-prebuilds image to v1.2.2-rc1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
         condition: service_completed_successfully
 
   godwoken:
-    image: ghcr.io/flouse/godwoken-prebuilds:1.2-gw-pull-721-merge-202206140118
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.2-rc1
     init: true
     healthcheck:
       test: /var/lib/layer2/healthcheck.sh
@@ -110,7 +110,7 @@ services:
         condition: service_completed_successfully
 
   godwoken-readonly:
-    image: ghcr.io/flouse/godwoken-prebuilds:1.2-gw-pull-721-merge-202206140118
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.2-rc1
     healthcheck:
       test: /var/lib/layer2/healthcheck.sh
       start_period: 10s


### PR DESCRIPTION
## ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.2-rc1
> https://github.com/nervosnetwork/godwoken/releases/tag/v1.2.2

This version is running on Godwoken testnet_v1.