### PR TITLE
fix: godwoken-readonly should update as well when manual build polyjuice

### DIFF
--- a/docker/manual-polyjuice.compose.yml
+++ b/docker/manual-polyjuice.compose.yml
@@ -18,3 +18,6 @@ services:
   godwoken:
     volumes:
       - ./manual-artifacts/polyjuice:/scripts/godwoken-polyjuice
+  godwoken-readonly:
+    volumes:
+      - ./manual-artifacts/polyjuice:/scripts/godwoken-polyjuice

--- a/docker/manual-scripts.compose.yml
+++ b/docker/manual-scripts.compose.yml
@@ -18,3 +18,6 @@ services:
   godwoken:
     volumes:
       - ./manual-artifacts/scripts:/scripts/godwoken-scripts
+  godwoken-readonly:
+    volumes:
+      - ./manual-artifacts/scripts:/scripts/godwoken-scripts


### PR DESCRIPTION
`godwoken` and `godwoken-readonly` should share the same Polyjuice scripts and Godwoken scripts.