### PR TITLE
fix: install git before installing capsule

### DIFF
--- a/docker/manual-image/Dockerfile
+++ b/docker/manual-image/Dockerfile
@@ -6,19 +6,19 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && \
-    apt install libssl-dev libsodium-dev libunwind-dev build-essential binutils upx curl wget -y && \
+    apt install libssl-dev libsodium-dev libunwind-dev build-essential binutils upx curl wget git -y && \
     DEBIAN_FRONTEND=noninteractive apt install rustc -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install cmake musl-tools clang libc++-dev autoconf libtool pkg-config unzip -y
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.54.0 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.61.0 -y
 ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup component add rustfmt
 RUN which cargo
 RUN which rustfmt
 
 # Install Capsule
-RUN cargo install ckb-capsule
+RUN cargo install ckb-capsule --version 0.8.0 --locked
 RUN which capsule
 
 # install node 14


### PR DESCRIPTION
Fixes https://github.com/RetricSu/godwoken-kicker/issues/312#issuecomment-1245104760

ckb-capsule cannot be compiled when building [manual-image/Dockerfile] due to a lack of git installed, required for the compiling process: https://github.com/nervosnetwork/capsule/blob/3e304767d8d4e2b6a445dce0266cb810d1961cb4/build.rs#L13-L22

```rust
    // get commit id
    let commit_id = std::process::Command::new("git")
        .args(&[
            "describe",
            "--dirty",
            "--always",
            "--match",
            "__EXCLUDE__",
            "--abbrev=7",
        ])
        .output()
        .ok()
        .and_then(|r| String::from_utf8(r.stdout).ok())
        .expect("commit id");
```